### PR TITLE
typos + fnd

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,9 +4,15 @@ Description: Client for the 'Orcid.org' 'API' (<https://orcid.org/>).
     Functions included for searching for people, searching by 'DOI',
     and searching by 'Orcid' 'ID'.
 Version: 0.4.2.9114
-Authors@R: c(person("Scott", "Chamberlain", role = c("aut", "cre"),
-    email = "myrmecocystus@gmail.com", 
-    comment = c(ORCID = "0000-0003-1444-9135")))
+Authors@R: 
+    c(person(given = "Scott",
+             family = "Chamberlain",
+             role = c("aut", "cre"),
+             email = "myrmecocystus@gmail.com",
+             comment = c(ORCID = "0000-0003-1444-9135")),
+      person(given = "rOpenSci",
+             role = "fnd",
+             comment = "https://ropensci.org/"))
 License: MIT + file LICENSE
 URL: https://github.com/ropensci/rorcid
 BugReports: https://github.com/ropensci/rorcid/issues
@@ -24,7 +30,7 @@ Imports:
 Suggests:
     testthat,
     knitr
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0.9000
 VignetteBuilder: knitr
 X-schema.org-applicationCategory: Literature
 X-schema.org-keywords: identifiers, literature, publications, citations, scholarly, people

--- a/R/auth.R
+++ b/R/auth.R
@@ -38,7 +38,7 @@
 #' @section ORCID OAuth Scopes:
 #' See <https://members.orcid.org/api/orcid-scopes> for more
 #'
-#' @section Computing evironments without browsers:
+#' @section Computing environments without browsers:
 #' One pitfall is when you are using rorcid on a server, and you're ssh'ed
 #' in, so that there's no way to open a browser to do the OAuth browser
 #' flow. Similarly for any other situation in which a browser can not be

--- a/R/orcid.r
+++ b/R/orcid.r
@@ -6,7 +6,7 @@
 #' SOLR syntax. See examples below. For all possible fields to query, do 
 #' `data(fields)`
 #' @param start Result number to start on. Keep in mind that pages start at 0.
-#' Deafult: 0
+#' Default: 0
 #' @param rows Numer of results to return. Default: 10. Max: 200
 #' @param recursive Keep drilling down until all records are retrieved for the 
 #' given query, default FALSE (logical). If `recursive=TRUE`, rows and 

--- a/README.Rmd
+++ b/README.Rmd
@@ -26,7 +26,7 @@ Orcid API docs:
 
 The package now works with the `v2.1` ORCID API now. It's too complicated to allow users to work with different versions of the API, so it's hard-coded to `v2.1`.
 
-## Computing evironments without browsers
+## Computing environments without browsers
 
 One pitfall is when you are using `rorcid` on a server, and you're ssh'ed
 in, so that there's no way to open a browser to do the OAuth browser

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Orcid API docs:
 
 The package now works with the `v2.1` ORCID API now. It's too complicated to allow users to work with different versions of the API, so it's hard-coded to `v2.1`.
 
-## Computing evironments without browsers
+## Computing environments without browsers
 
 One pitfall is when you are using `rorcid` on a server, and you're ssh'ed
 in, so that there's no way to open a browser to do the OAuth browser

--- a/man/orcid.Rd
+++ b/man/orcid.Rd
@@ -16,7 +16,7 @@ SOLR syntax. See examples below. For all possible fields to query, do
 \code{data(fields)}}
 
 \item{start}{Result number to start on. Keep in mind that pages start at 0.
-Deafult: 0}
+Default: 0}
 
 \item{rows}{Numer of results to return. Default: 10. Max: 200}
 

--- a/man/orcid_activities.Rd
+++ b/man/orcid_activities.Rd
@@ -13,14 +13,14 @@ XXXX-XXXX-XXXX-XXXX. required.}
 \item{...}{Curl options passed on to \code{\link[crul:HttpClient]{crul::HttpClient()}}}
 }
 \value{
-A list of results for each Orcid ID passed in, with each element 
+A list of results for each Orcid ID passed in, with each element
 named by the Orcid ID
 }
 \description{
 Get activities for a person
 }
 \details{
-This function is vectorized, so you can pass in many ORCID's, and 
+This function is vectorized, so you can pass in many ORCID's, and
 there's an element returned for each ORCID you put in.
 }
 \examples{

--- a/man/orcid_address.Rd
+++ b/man/orcid_address.Rd
@@ -22,14 +22,14 @@ XXXX-XXXX-XXXX-XXXX. required.}
 \item{...}{Curl options passed on to \code{\link[crul:HttpClient]{crul::HttpClient()}}}
 }
 \value{
-A list of results for each Orcid ID passed in, with each element 
+A list of results for each Orcid ID passed in, with each element
 named by the Orcid ID
 }
 \description{
 Get address information for a person
 }
 \details{
-This function is vectorized, so you can pass in many ORCID's, and 
+This function is vectorized, so you can pass in many ORCID's, and
 there's an element returned for each ORCID you put in.
 }
 \examples{

--- a/man/orcid_auth.Rd
+++ b/man/orcid_auth.Rd
@@ -54,7 +54,7 @@ this prepares you for when that happens :)
 See \url{https://members.orcid.org/api/orcid-scopes} for more
 }
 
-\section{Computing evironments without browsers}{
+\section{Computing environments without browsers}{
 
 One pitfall is when you are using rorcid on a server, and you're ssh'ed
 in, so that there's no way to open a browser to do the OAuth browser

--- a/man/orcid_bio.Rd
+++ b/man/orcid_bio.Rd
@@ -19,14 +19,14 @@ XXXX-XXXX-XXXX-XXXX. required.}
 \item{...}{Curl options passed on to \code{\link[crul:HttpClient]{crul::HttpClient()}}}
 }
 \value{
-A list of results for each Orcid ID passed in, with each element 
+A list of results for each Orcid ID passed in, with each element
 named by the Orcid ID
 }
 \description{
 Get biography data for a person
 }
 \details{
-This function is vectorized, so you can pass in many ORCID's, and 
+This function is vectorized, so you can pass in many ORCID's, and
 there's an element returned for each ORCID you put in.
 }
 \examples{

--- a/man/orcid_doi.Rd
+++ b/man/orcid_doi.Rd
@@ -4,7 +4,8 @@
 \alias{orcid_doi}
 \title{Search for ORCID ID's using DOIs}
 \usage{
-orcid_doi(dois = NULL, start = NULL, rows = NULL, fuzzy = FALSE, ...)
+orcid_doi(dois = NULL, start = NULL, rows = NULL, fuzzy = FALSE,
+  ...)
 }
 \arguments{
 \item{dois}{(character) Digital object identifier (DOI), a vector fo DOIs.}

--- a/man/orcid_educations.Rd
+++ b/man/orcid_educations.Rd
@@ -26,14 +26,14 @@ Default: \code{FALSE}}
 \item{...}{Curl options passed on to \code{\link[crul:HttpClient]{crul::HttpClient()}}}
 }
 \value{
-A list of results for each Orcid ID passed in, with each element 
+A list of results for each Orcid ID passed in, with each element
 named by the Orcid ID
 }
 \description{
 Get education information for a person
 }
 \details{
-This function is vectorized, so you can pass in many ORCID's, and 
+This function is vectorized, so you can pass in many ORCID's, and
 there's an element returned for each ORCID you put in.
 }
 \examples{

--- a/man/orcid_email.Rd
+++ b/man/orcid_email.Rd
@@ -13,14 +13,14 @@ XXXX-XXXX-XXXX-XXXX. required.}
 \item{...}{Curl options passed on to \code{\link[crul:HttpClient]{crul::HttpClient()}}}
 }
 \value{
-A list of results for each Orcid ID passed in, with each element 
+A list of results for each Orcid ID passed in, with each element
 named by the Orcid ID
 }
 \description{
 Get education information for a person
 }
 \details{
-This function is vectorized, so you can pass in many ORCID's, and 
+This function is vectorized, so you can pass in many ORCID's, and
 there's an element returned for each ORCID you put in.
 }
 \examples{

--- a/man/orcid_employments.Rd
+++ b/man/orcid_employments.Rd
@@ -26,14 +26,14 @@ Default: \code{FALSE}}
 \item{...}{Curl options passed on to \code{\link[crul:HttpClient]{crul::HttpClient()}}}
 }
 \value{
-A list of results for each Orcid ID passed in, with each element 
+A list of results for each Orcid ID passed in, with each element
 named by the Orcid ID
 }
 \description{
 Get employment information for a person
 }
 \details{
-This function is vectorized, so you can pass in many ORCID's, and 
+This function is vectorized, so you can pass in many ORCID's, and
 there's an element returned for each ORCID you put in.
 }
 \examples{

--- a/man/orcid_external_identifiers.Rd
+++ b/man/orcid_external_identifiers.Rd
@@ -23,14 +23,14 @@ XXXX-XXXX-XXXX-XXXX. required.}
 \item{...}{Curl options passed on to \code{\link[crul:HttpClient]{crul::HttpClient()}}}
 }
 \value{
-A list of results for each Orcid ID passed in, with each element 
+A list of results for each Orcid ID passed in, with each element
 named by the Orcid ID
 }
 \description{
 Get education information for a person
 }
 \details{
-This function is vectorized, so you can pass in many ORCID's, and 
+This function is vectorized, so you can pass in many ORCID's, and
 there's an element returned for each ORCID you put in.
 }
 \examples{

--- a/man/orcid_fundings.Rd
+++ b/man/orcid_fundings.Rd
@@ -26,14 +26,14 @@ Default: \code{FALSE}}
 \item{...}{Curl options passed on to \code{\link[crul:HttpClient]{crul::HttpClient()}}}
 }
 \value{
-A list of results for each Orcid ID passed in, with each element 
+A list of results for each Orcid ID passed in, with each element
 named by the Orcid ID
 }
 \description{
 Get funding information for a person
 }
 \details{
-This function is vectorized, so you can pass in many ORCID's, and 
+This function is vectorized, so you can pass in many ORCID's, and
 there's an element returned for each ORCID you put in.
 }
 \examples{

--- a/man/orcid_keywords.Rd
+++ b/man/orcid_keywords.Rd
@@ -4,7 +4,8 @@
 \alias{orcid_keywords}
 \title{Get education information for a person}
 \usage{
-orcid_keywords(orcid, put_code = NULL, format = "application/json", ...)
+orcid_keywords(orcid, put_code = NULL, format = "application/json",
+  ...)
 }
 \arguments{
 \item{orcid}{(character) Orcid identifier(s), of the form
@@ -22,14 +23,14 @@ XXXX-XXXX-XXXX-XXXX. required.}
 \item{...}{Curl options passed on to \code{\link[crul:HttpClient]{crul::HttpClient()}}}
 }
 \value{
-A list of results for each Orcid ID passed in, with each element 
+A list of results for each Orcid ID passed in, with each element
 named by the Orcid ID
 }
 \description{
 Get education information for a person
 }
 \details{
-This function is vectorized, so you can pass in many ORCID's, and 
+This function is vectorized, so you can pass in many ORCID's, and
 there's an element returned for each ORCID you put in.
 }
 \examples{

--- a/man/orcid_other_names.Rd
+++ b/man/orcid_other_names.Rd
@@ -4,7 +4,8 @@
 \alias{orcid_other_names}
 \title{Get education information for a person}
 \usage{
-orcid_other_names(orcid, put_code = NULL, format = "application/json", ...)
+orcid_other_names(orcid, put_code = NULL, format = "application/json",
+  ...)
 }
 \arguments{
 \item{orcid}{(character) Orcid identifier(s), of the form
@@ -22,14 +23,14 @@ XXXX-XXXX-XXXX-XXXX. required.}
 \item{...}{Curl options passed on to \code{\link[crul:HttpClient]{crul::HttpClient()}}}
 }
 \value{
-A list of results for each Orcid ID passed in, with each element 
+A list of results for each Orcid ID passed in, with each element
 named by the Orcid ID
 }
 \description{
 Get education information for a person
 }
 \details{
-This function is vectorized, so you can pass in many ORCID's, and 
+This function is vectorized, so you can pass in many ORCID's, and
 there's an element returned for each ORCID you put in.
 }
 \examples{

--- a/man/orcid_peer_reviews.Rd
+++ b/man/orcid_peer_reviews.Rd
@@ -26,14 +26,14 @@ Default: \code{FALSE}}
 \item{...}{Curl options passed on to \code{\link[crul:HttpClient]{crul::HttpClient()}}}
 }
 \value{
-A list of results for each Orcid ID passed in, with each element 
+A list of results for each Orcid ID passed in, with each element
 named by the Orcid ID
 }
 \description{
 Get peer review information for a person
 }
 \details{
-This function is vectorized, so you can pass in many ORCID's, and 
+This function is vectorized, so you can pass in many ORCID's, and
 there's an element returned for each ORCID you put in.
 }
 \examples{

--- a/man/orcid_person.Rd
+++ b/man/orcid_person.Rd
@@ -15,14 +15,14 @@ XXXX-XXXX-XXXX-XXXX. required.}
 \item{...}{Curl options passed on to \code{\link[crul:HttpClient]{crul::HttpClient()}}}
 }
 \value{
-A list of results for each Orcid ID passed in, with each element 
+A list of results for each Orcid ID passed in, with each element
 named by the Orcid ID
 }
 \description{
 Get personal data for a person
 }
 \details{
-This function is vectorized, so you can pass in many ORCID's, and 
+This function is vectorized, so you can pass in many ORCID's, and
 there's an element returned for each ORCID you put in.
 }
 \examples{

--- a/man/orcid_researcher_urls.Rd
+++ b/man/orcid_researcher_urls.Rd
@@ -4,8 +4,8 @@
 \alias{orcid_researcher_urls}
 \title{Get researcher urls for a person}
 \usage{
-orcid_researcher_urls(orcid, put_code = NULL, format = "application/json",
-  ...)
+orcid_researcher_urls(orcid, put_code = NULL,
+  format = "application/json", ...)
 }
 \arguments{
 \item{orcid}{(character) Orcid identifier(s), of the form
@@ -23,14 +23,14 @@ XXXX-XXXX-XXXX-XXXX. required.}
 \item{...}{Curl options passed on to \code{\link[crul:HttpClient]{crul::HttpClient()}}}
 }
 \value{
-A list of results for each Orcid ID passed in, with each element 
+A list of results for each Orcid ID passed in, with each element
 named by the Orcid ID
 }
 \description{
 Get researcher urls for a person
 }
 \details{
-This function is vectorized, so you can pass in many ORCID's, and 
+This function is vectorized, so you can pass in many ORCID's, and
 there's an element returned for each ORCID you put in.
 }
 \examples{

--- a/man/orcid_works.Rd
+++ b/man/orcid_works.Rd
@@ -22,14 +22,14 @@ XXXX-XXXX-XXXX-XXXX. required.}
 \item{...}{Curl options passed on to \code{\link[crul:HttpClient]{crul::HttpClient()}}}
 }
 \value{
-A list of results for each Orcid ID passed in, with each element 
+A list of results for each Orcid ID passed in, with each element
 named by the Orcid ID
 }
 \description{
 Get works for a person
 }
 \details{
-This function is vectorized, so you can pass in many ORCID's, and 
+This function is vectorized, so you can pass in many ORCID's, and
 there's an element returned for each ORCID you put in.
 }
 \examples{


### PR DESCRIPTION
* Saw a typo, ran `spelling::spell_check_package()` and found another one.

* Added rOpenSci as fnd.

* Other changes due to my different `roxygen2` version I think? This makes me wish all packages built docs on Travis! (possible, haven't tried that yet, but `tic` would help)