### PR TITLE
Add support to extract BibTeX entries direcly from ORCID (if available)

### DIFF
--- a/R/orcid_citations.R
+++ b/R/orcid_citations.R
@@ -222,9 +222,9 @@ do_all <- function(m, orcid, put_code, cr_format, cr_style, cr_locale, ...) {
 
     ##try to extract BibTeX, if this fails use the conventional way
     citation <- try(
-      extract_BibTeX(cite_put(orcid, pc, ctype = "application/vnd.orcid+json; qs=4")))
+      extract_bibtex(cite_put(orcid, pc, ctype = "application/vnd.orcid+json; qs=4")))
 
-    if(class(citation) == "try-error")
+    if (inherits(citation, "try-error"))
       citation <- cite_put(orcid, pc)
 
     list(put = pc, ids = zzz$`external-id-value`,

--- a/R/orcid_citations.R
+++ b/R/orcid_citations.R
@@ -1,72 +1,72 @@
 #' Get citations
 #'
 #' @export
-#' @param orcid (character) Orcid identifier(s) of the form
+#' @param orcid (character) Orcid identifier(s) of the form 
 #' XXXX-XXXX-XXXX-XXXX. required.
-#' @param put_code (character/integer) one or more put codes. up to
+#' @param put_code (character/integer) one or more put codes. up to 
 #' 50. optional
-#' @param cr_format Used in Crossref queries only. Name of the format. One of
+#' @param cr_format Used in Crossref queries only. Name of the format. One of 
 #' "rdf-xml", "turtle",
-#' "citeproc-json", "citeproc-json-ish", "text", "ris", "bibtex" (default),
-#' "crossref-xml", "datacite-xml","bibentry", or "crossref-tdm". The format
+#' "citeproc-json", "citeproc-json-ish", "text", "ris", "bibtex" (default), 
+#' "crossref-xml", "datacite-xml","bibentry", or "crossref-tdm". The format 
 #' "citeproc-json-ish" is a format that is not quite proper citeproc-json.
 #' passed to `rcrossref::cr_cn`. The special "citeproc2bibtex" value asks
-#' for citeproc-json from Crossref, then converts it into bibtex format
+#' for citeproc-json from Crossref, then converts it into bibtex format 
 #' using [handlr::HandlrClient]
-#' @param cr_style Used in Crossref queries only. A CSL style (for text
-#' format only). See ‘get_styles()’ for options. Default: apa.
+#' @param cr_style Used in Crossref queries only. A CSL style (for text 
+#' format only). See ‘get_styles()’ for options. Default: apa. 
 #' passed to `rcrossref::cr_cn`
-#' @param cr_locale Used in Crossref queries only. Language locale.
+#' @param cr_locale Used in Crossref queries only. Language locale. 
 #' See [Sys.getlocale], passed to `rcrossref::cr_cn`
 #' @param ... Curl options passed on to [crul::HttpClient]
 #' @template deets
 #' @details This function is focused on getting citations only.
 #' You can get all citations for an ORCID, or for certain works
 #' using a PUT code, or for many PUT codes.
-#'
-#' We attempt to get citations via Crossref using \pkg{rcrossref}
-#' whenever possible as they are the most flexible and don't have as
-#' many mistakes in the text. If there is no DOI, we fetch the
+#' 
+#' We attempt to get citations via Crossref using \pkg{rcrossref} 
+#' whenever possible as they are the most flexible and don't have as 
+#' many mistakes in the text. If there is no DOI, we fetch the 
 #' citation from ORCID.
-#'
+#' 
 #' Right now we get JSON citations back. We'd like to support bibtex
 #' format. DOI.org supports this but not ORCID.
 #'
 #' @return data.frame, with the columns:
-#'
+#' 
 #' - put: ORCID PUT code, identifying the work identifier in ORCID's records
 #' - id: the external identifier
 #' - id_type: the type of external identifier
 #' - format: the citation format retrieved
 #' - citation: the citation as JSON
-#'
+#' 
 #' @examples \dontrun{
 #' (res <- orcid_citations(orcid = "0000-0002-9341-7985"))
 #' (res2 <- orcid_citations(orcid = "0000-0002-1642-628X"))
 #' (res2 <- orcid_citations(orcid = c("0000-0002-9341-7985", "0000-0002-1642-628X")))
-#'
+#' 
 #' # get individual works
 #' ## a single put code
 #' (a <- orcid_citations(orcid = "0000-0002-9341-7985", put_code = 5011717))
 #' ## many put codes
-#' (b <- orcid_citations(orcid = "0000-0002-9341-7985",
+#' (b <- orcid_citations(orcid = "0000-0002-9341-7985", 
 #'    put_code = c(5011717, 15536016)))
-#'
+#' 
 #' # request other formats, Crossref only
 #' orcid_citations(orcid = "0000-0002-9341-7985", cr_format = "turtle")
-#'
+#' 
 #' # parse citation data if you wish
 #' # for parsing bibtex can use bibtex package or others
 #' (res <- orcid_citations(orcid = "0000-0002-9341-7985"))
 #' lapply(res[res$format == "csl-json", "citation"][[1]], jsonlite::fromJSON)
-#'
+#' 
 #' # lots of citations
 #' orcid_citations(orcid = "0000-0001-8642-6325")
-#'
+#' 
 #' # example with no external identifier, returns NA's
 #' orcid_citations(orcid = "0000-0001-8642-6325", 26222265)
 #' }
-orcid_citations <- function(orcid, put_code = NULL, cr_format = "bibtex",
+orcid_citations <- function(orcid, put_code = NULL, cr_format = "bibtex", 
   cr_style = "apa", cr_locale = "en-US", ...) {
 
   if (!is.null(put_code)) {
@@ -76,7 +76,7 @@ orcid_citations <- function(orcid, put_code = NULL, cr_format = "bibtex",
   }
 
   tmp <- orcid_works(orcid, put_code)
-
+  
   dat <- if (!is.null(put_code)) {
     if (NROW(tmp[[1]]$works) > 1) {
       list(split(tmp[[1]]$works, tmp[[1]]$works$`work.put-code`))
@@ -87,10 +87,9 @@ orcid_citations <- function(orcid, put_code = NULL, cr_format = "bibtex",
     lapply(tmp, function(w) split(w$works, w$works$`put-code`))
   }
 
-
   if (length(orcid) > 1) {
-    Map(function(a, b) each_orcid(a, b, put_code, cr_format, cr_style, cr_locale),
-      dat, orcid, ...)
+    Map(function(a, b) each_orcid(a, b, put_code, cr_format, cr_style, cr_locale), 
+      dat, orcid, ...) 
   } else {
     do_all(dat[[1]], orcid, put_code, cr_format, cr_style, cr_locale, ...)
   }
@@ -109,9 +108,9 @@ each_orcid <- function(m, orcid, put_code, cr_format, cr_style, cr_locale, ...) 
         process_cites(df, pc, orcid, cr_format, cr_style, cr_locale, ...)
       } else {
         df <- z$`external-ids`
-        Map(process_cites, df, pc, orcid = orcid, cr_format = cr_format,
+        Map(process_cites, df, pc, orcid = orcid, cr_format = cr_format, 
           cr_style = cr_style, cr_locale = cr_locale, ...)
-      }
+      } 
     } else {
       df <- z$`external-ids.external-id`[[1]]
       process_cites(df, pc, orcid, cr_format, cr_style, cr_locale, ...)
@@ -125,7 +124,7 @@ each_orcid <- function(m, orcid, put_code, cr_format, cr_style, cr_locale, ...) 
 
 process_cites <- function(df, pc, orcid, cr_format, cr_style, cr_locale, ...) {
   if (length(df) == 0) {
-    return(list(put = pc, id = NA_character_, id_type = NA_character_,
+    return(list(put = pc, id = NA_character_, id_type = NA_character_, 
       format = NA_character_, citation = ""))
   }
   if ("doi" %in% df$`external-id-type`) {
@@ -165,10 +164,10 @@ cite_doi <- function(x, cr_format = "bibtex", cr_style = "apa", cr_locale = "en-
   rcrossref::cr_cn(x, format = cr_format, style = cr_style, locale = cr_locale, raw = TRUE, ...)
 }
 
-cite_put <- function(orcid, pc, ctype = "application/vnd.citationstyles.csl+json", ...) {
-  orcid_prof_helper(orcid, file.path("work", pc),
-    ctype = ctype,
-    #ctype = "application/x-bibtex",
+cite_put <- function(orcid, pc, ...) {
+  orcid_prof_helper(orcid, file.path("work", pc), 
+    ctype = "application/vnd.citationstyles.csl+json", 
+    # ctype = "application/x-bibtex", 
     parse = FALSE, ...)
 }
 
@@ -220,18 +219,9 @@ do_all <- function(m, orcid, put_code, cr_format, cr_style, cr_locale, ...) {
   without_doi_citations <- lapply(without_doi, function(z) {
     zzz <- z$`external-ids.external-id`[[1]] %||% z$`work.external-ids.external-id`[[1]]
     pc <- z$`put-code` %||% z$`work.put-code`
-
-    ##try to extract BibTeX, if this fails use the conventional way
-    citation <- try(
-      extract_BibTeX(cite_put(orcid, pc, ctype = "application/vnd.orcid+json; qs=4")))
-
-    if(class(citation) == "try-error")
-      citation <- cite_put(orcid, pc)
-
-    list(put = pc, ids = zzz$`external-id-value`,
+    list(put = pc, ids = zzz$`external-id-value`, 
       type = zzz$`external-id-type`, format = cr_format,
-      citation = citation)
-
+      citation = cite_put(orcid, pc))
   })
   as_dt(c(with_doi_citations, without_doi_citations))
 }

--- a/R/orcid_citations.R
+++ b/R/orcid_citations.R
@@ -1,72 +1,72 @@
 #' Get citations
 #'
 #' @export
-#' @param orcid (character) Orcid identifier(s) of the form 
+#' @param orcid (character) Orcid identifier(s) of the form
 #' XXXX-XXXX-XXXX-XXXX. required.
-#' @param put_code (character/integer) one or more put codes. up to 
+#' @param put_code (character/integer) one or more put codes. up to
 #' 50. optional
-#' @param cr_format Used in Crossref queries only. Name of the format. One of 
+#' @param cr_format Used in Crossref queries only. Name of the format. One of
 #' "rdf-xml", "turtle",
-#' "citeproc-json", "citeproc-json-ish", "text", "ris", "bibtex" (default), 
-#' "crossref-xml", "datacite-xml","bibentry", or "crossref-tdm". The format 
+#' "citeproc-json", "citeproc-json-ish", "text", "ris", "bibtex" (default),
+#' "crossref-xml", "datacite-xml","bibentry", or "crossref-tdm". The format
 #' "citeproc-json-ish" is a format that is not quite proper citeproc-json.
 #' passed to `rcrossref::cr_cn`. The special "citeproc2bibtex" value asks
-#' for citeproc-json from Crossref, then converts it into bibtex format 
+#' for citeproc-json from Crossref, then converts it into bibtex format
 #' using [handlr::HandlrClient]
-#' @param cr_style Used in Crossref queries only. A CSL style (for text 
-#' format only). See ‘get_styles()’ for options. Default: apa. 
+#' @param cr_style Used in Crossref queries only. A CSL style (for text
+#' format only). See ‘get_styles()’ for options. Default: apa.
 #' passed to `rcrossref::cr_cn`
-#' @param cr_locale Used in Crossref queries only. Language locale. 
+#' @param cr_locale Used in Crossref queries only. Language locale.
 #' See [Sys.getlocale], passed to `rcrossref::cr_cn`
 #' @param ... Curl options passed on to [crul::HttpClient]
 #' @template deets
 #' @details This function is focused on getting citations only.
 #' You can get all citations for an ORCID, or for certain works
 #' using a PUT code, or for many PUT codes.
-#' 
-#' We attempt to get citations via Crossref using \pkg{rcrossref} 
-#' whenever possible as they are the most flexible and don't have as 
-#' many mistakes in the text. If there is no DOI, we fetch the 
+#'
+#' We attempt to get citations via Crossref using \pkg{rcrossref}
+#' whenever possible as they are the most flexible and don't have as
+#' many mistakes in the text. If there is no DOI, we fetch the
 #' citation from ORCID.
-#' 
+#'
 #' Right now we get JSON citations back. We'd like to support bibtex
 #' format. DOI.org supports this but not ORCID.
 #'
 #' @return data.frame, with the columns:
-#' 
+#'
 #' - put: ORCID PUT code, identifying the work identifier in ORCID's records
 #' - id: the external identifier
 #' - id_type: the type of external identifier
 #' - format: the citation format retrieved
 #' - citation: the citation as JSON
-#' 
+#'
 #' @examples \dontrun{
 #' (res <- orcid_citations(orcid = "0000-0002-9341-7985"))
 #' (res2 <- orcid_citations(orcid = "0000-0002-1642-628X"))
 #' (res2 <- orcid_citations(orcid = c("0000-0002-9341-7985", "0000-0002-1642-628X")))
-#' 
+#'
 #' # get individual works
 #' ## a single put code
 #' (a <- orcid_citations(orcid = "0000-0002-9341-7985", put_code = 5011717))
 #' ## many put codes
-#' (b <- orcid_citations(orcid = "0000-0002-9341-7985", 
+#' (b <- orcid_citations(orcid = "0000-0002-9341-7985",
 #'    put_code = c(5011717, 15536016)))
-#' 
+#'
 #' # request other formats, Crossref only
 #' orcid_citations(orcid = "0000-0002-9341-7985", cr_format = "turtle")
-#' 
+#'
 #' # parse citation data if you wish
 #' # for parsing bibtex can use bibtex package or others
 #' (res <- orcid_citations(orcid = "0000-0002-9341-7985"))
 #' lapply(res[res$format == "csl-json", "citation"][[1]], jsonlite::fromJSON)
-#' 
+#'
 #' # lots of citations
 #' orcid_citations(orcid = "0000-0001-8642-6325")
-#' 
+#'
 #' # example with no external identifier, returns NA's
 #' orcid_citations(orcid = "0000-0001-8642-6325", 26222265)
 #' }
-orcid_citations <- function(orcid, put_code = NULL, cr_format = "bibtex", 
+orcid_citations <- function(orcid, put_code = NULL, cr_format = "bibtex",
   cr_style = "apa", cr_locale = "en-US", ...) {
 
   if (!is.null(put_code)) {
@@ -76,7 +76,7 @@ orcid_citations <- function(orcid, put_code = NULL, cr_format = "bibtex",
   }
 
   tmp <- orcid_works(orcid, put_code)
-  
+
   dat <- if (!is.null(put_code)) {
     if (NROW(tmp[[1]]$works) > 1) {
       list(split(tmp[[1]]$works, tmp[[1]]$works$`work.put-code`))
@@ -88,8 +88,8 @@ orcid_citations <- function(orcid, put_code = NULL, cr_format = "bibtex",
   }
 
   if (length(orcid) > 1) {
-    Map(function(a, b) each_orcid(a, b, put_code, cr_format, cr_style, cr_locale), 
-      dat, orcid, ...) 
+    Map(function(a, b) each_orcid(a, b, put_code, cr_format, cr_style, cr_locale),
+      dat, orcid, ...)
   } else {
     do_all(dat[[1]], orcid, put_code, cr_format, cr_style, cr_locale, ...)
   }
@@ -108,9 +108,9 @@ each_orcid <- function(m, orcid, put_code, cr_format, cr_style, cr_locale, ...) 
         process_cites(df, pc, orcid, cr_format, cr_style, cr_locale, ...)
       } else {
         df <- z$`external-ids`
-        Map(process_cites, df, pc, orcid = orcid, cr_format = cr_format, 
+        Map(process_cites, df, pc, orcid = orcid, cr_format = cr_format,
           cr_style = cr_style, cr_locale = cr_locale, ...)
-      } 
+      }
     } else {
       df <- z$`external-ids.external-id`[[1]]
       process_cites(df, pc, orcid, cr_format, cr_style, cr_locale, ...)
@@ -124,7 +124,7 @@ each_orcid <- function(m, orcid, put_code, cr_format, cr_style, cr_locale, ...) 
 
 process_cites <- function(df, pc, orcid, cr_format, cr_style, cr_locale, ...) {
   if (length(df) == 0) {
-    return(list(put = pc, id = NA_character_, id_type = NA_character_, 
+    return(list(put = pc, id = NA_character_, id_type = NA_character_,
       format = NA_character_, citation = ""))
   }
   if ("doi" %in% df$`external-id-type`) {
@@ -164,11 +164,11 @@ cite_doi <- function(x, cr_format = "bibtex", cr_style = "apa", cr_locale = "en-
   rcrossref::cr_cn(x, format = cr_format, style = cr_style, locale = cr_locale, raw = TRUE, ...)
 }
 
-cite_put <- function(orcid, pc, ...) {
-  orcid_prof_helper(orcid, file.path("work", pc), 
-    ctype = "application/vnd.citationstyles.csl+json", 
-    # ctype = "application/x-bibtex", 
-    parse = FALSE, ...)
+cite_put <- function(orcid, pc, ctype = "application/vnd.citationstyles.csl+json", ...) {
+  orcid_prof_helper(orcid, file.path("work", pc),
+                    ctype = ctype,
+                    #ctype = "application/x-bibtex",
+                    parse = FALSE, ...)
 }
 
 has_doi <- function(x) {
@@ -219,9 +219,18 @@ do_all <- function(m, orcid, put_code, cr_format, cr_style, cr_locale, ...) {
   without_doi_citations <- lapply(without_doi, function(z) {
     zzz <- z$`external-ids.external-id`[[1]] %||% z$`work.external-ids.external-id`[[1]]
     pc <- z$`put-code` %||% z$`work.put-code`
-    list(put = pc, ids = zzz$`external-id-value`, 
-      type = zzz$`external-id-type`, format = cr_format,
-      citation = cite_put(orcid, pc))
+
+    ##try to extract BibTeX, if this fails use the conventional way
+    citation <- try(
+      extract_BibTeX(cite_put(orcid, pc, ctype = "application/vnd.orcid+json; qs=4")))
+
+    if(class(citation) == "try-error")
+      citation <- cite_put(orcid, pc)
+
+    list(put = pc, ids = zzz$`external-id-value`,
+         type = zzz$`external-id-type`, format = cr_format,
+         citation = citation)
+
   })
   as_dt(c(with_doi_citations, without_doi_citations))
 }

--- a/R/orcid_citations.R
+++ b/R/orcid_citations.R
@@ -1,72 +1,72 @@
 #' Get citations
 #'
 #' @export
-#' @param orcid (character) Orcid identifier(s) of the form
+#' @param orcid (character) Orcid identifier(s) of the form 
 #' XXXX-XXXX-XXXX-XXXX. required.
-#' @param put_code (character/integer) one or more put codes. up to
+#' @param put_code (character/integer) one or more put codes. up to 
 #' 50. optional
-#' @param cr_format Used in Crossref queries only. Name of the format. One of
+#' @param cr_format Used in Crossref queries only. Name of the format. One of 
 #' "rdf-xml", "turtle",
-#' "citeproc-json", "citeproc-json-ish", "text", "ris", "bibtex" (default),
-#' "crossref-xml", "datacite-xml","bibentry", or "crossref-tdm". The format
+#' "citeproc-json", "citeproc-json-ish", "text", "ris", "bibtex" (default), 
+#' "crossref-xml", "datacite-xml","bibentry", or "crossref-tdm". The format 
 #' "citeproc-json-ish" is a format that is not quite proper citeproc-json.
 #' passed to `rcrossref::cr_cn`. The special "citeproc2bibtex" value asks
-#' for citeproc-json from Crossref, then converts it into bibtex format
+#' for citeproc-json from Crossref, then converts it into bibtex format 
 #' using [handlr::HandlrClient]
-#' @param cr_style Used in Crossref queries only. A CSL style (for text
-#' format only). See ‘get_styles()’ for options. Default: apa.
+#' @param cr_style Used in Crossref queries only. A CSL style (for text 
+#' format only). See ‘get_styles()’ for options. Default: apa. 
 #' passed to `rcrossref::cr_cn`
-#' @param cr_locale Used in Crossref queries only. Language locale.
+#' @param cr_locale Used in Crossref queries only. Language locale. 
 #' See [Sys.getlocale], passed to `rcrossref::cr_cn`
 #' @param ... Curl options passed on to [crul::HttpClient]
 #' @template deets
 #' @details This function is focused on getting citations only.
 #' You can get all citations for an ORCID, or for certain works
 #' using a PUT code, or for many PUT codes.
-#'
-#' We attempt to get citations via Crossref using \pkg{rcrossref}
-#' whenever possible as they are the most flexible and don't have as
-#' many mistakes in the text. If there is no DOI, we fetch the
+#' 
+#' We attempt to get citations via Crossref using \pkg{rcrossref} 
+#' whenever possible as they are the most flexible and don't have as 
+#' many mistakes in the text. If there is no DOI, we fetch the 
 #' citation from ORCID.
-#'
+#' 
 #' Right now we get JSON citations back. We'd like to support bibtex
 #' format. DOI.org supports this but not ORCID.
 #'
 #' @return data.frame, with the columns:
-#'
+#' 
 #' - put: ORCID PUT code, identifying the work identifier in ORCID's records
 #' - id: the external identifier
 #' - id_type: the type of external identifier
 #' - format: the citation format retrieved
 #' - citation: the citation as JSON
-#'
+#' 
 #' @examples \dontrun{
 #' (res <- orcid_citations(orcid = "0000-0002-9341-7985"))
 #' (res2 <- orcid_citations(orcid = "0000-0002-1642-628X"))
 #' (res2 <- orcid_citations(orcid = c("0000-0002-9341-7985", "0000-0002-1642-628X")))
-#'
+#' 
 #' # get individual works
 #' ## a single put code
 #' (a <- orcid_citations(orcid = "0000-0002-9341-7985", put_code = 5011717))
 #' ## many put codes
-#' (b <- orcid_citations(orcid = "0000-0002-9341-7985",
+#' (b <- orcid_citations(orcid = "0000-0002-9341-7985", 
 #'    put_code = c(5011717, 15536016)))
-#'
+#' 
 #' # request other formats, Crossref only
 #' orcid_citations(orcid = "0000-0002-9341-7985", cr_format = "turtle")
-#'
+#' 
 #' # parse citation data if you wish
 #' # for parsing bibtex can use bibtex package or others
 #' (res <- orcid_citations(orcid = "0000-0002-9341-7985"))
 #' lapply(res[res$format == "csl-json", "citation"][[1]], jsonlite::fromJSON)
-#'
+#' 
 #' # lots of citations
 #' orcid_citations(orcid = "0000-0001-8642-6325")
-#'
+#' 
 #' # example with no external identifier, returns NA's
 #' orcid_citations(orcid = "0000-0001-8642-6325", 26222265)
 #' }
-orcid_citations <- function(orcid, put_code = NULL, cr_format = "bibtex",
+orcid_citations <- function(orcid, put_code = NULL, cr_format = "bibtex", 
   cr_style = "apa", cr_locale = "en-US", ...) {
 
   if (!is.null(put_code)) {
@@ -76,7 +76,7 @@ orcid_citations <- function(orcid, put_code = NULL, cr_format = "bibtex",
   }
 
   tmp <- orcid_works(orcid, put_code)
-
+  
   dat <- if (!is.null(put_code)) {
     if (NROW(tmp[[1]]$works) > 1) {
       list(split(tmp[[1]]$works, tmp[[1]]$works$`work.put-code`))
@@ -88,8 +88,8 @@ orcid_citations <- function(orcid, put_code = NULL, cr_format = "bibtex",
   }
 
   if (length(orcid) > 1) {
-    Map(function(a, b) each_orcid(a, b, put_code, cr_format, cr_style, cr_locale),
-      dat, orcid, ...)
+    Map(function(a, b) each_orcid(a, b, put_code, cr_format, cr_style, cr_locale), 
+      dat, orcid, ...) 
   } else {
     do_all(dat[[1]], orcid, put_code, cr_format, cr_style, cr_locale, ...)
   }
@@ -108,9 +108,9 @@ each_orcid <- function(m, orcid, put_code, cr_format, cr_style, cr_locale, ...) 
         process_cites(df, pc, orcid, cr_format, cr_style, cr_locale, ...)
       } else {
         df <- z$`external-ids`
-        Map(process_cites, df, pc, orcid = orcid, cr_format = cr_format,
+        Map(process_cites, df, pc, orcid = orcid, cr_format = cr_format, 
           cr_style = cr_style, cr_locale = cr_locale, ...)
-      }
+      } 
     } else {
       df <- z$`external-ids.external-id`[[1]]
       process_cites(df, pc, orcid, cr_format, cr_style, cr_locale, ...)
@@ -124,7 +124,7 @@ each_orcid <- function(m, orcid, put_code, cr_format, cr_style, cr_locale, ...) 
 
 process_cites <- function(df, pc, orcid, cr_format, cr_style, cr_locale, ...) {
   if (length(df) == 0) {
-    return(list(put = pc, id = NA_character_, id_type = NA_character_,
+    return(list(put = pc, id = NA_character_, id_type = NA_character_, 
       format = NA_character_, citation = ""))
   }
   if ("doi" %in% df$`external-id-type`) {
@@ -164,11 +164,11 @@ cite_doi <- function(x, cr_format = "bibtex", cr_style = "apa", cr_locale = "en-
   rcrossref::cr_cn(x, format = cr_format, style = cr_style, locale = cr_locale, raw = TRUE, ...)
 }
 
-cite_put <- function(orcid, pc, ctype = "application/vnd.citationstyles.csl+json", ...) {
-  orcid_prof_helper(orcid, file.path("work", pc),
-                    ctype = ctype,
-                    #ctype = "application/x-bibtex",
-                    parse = FALSE, ...)
+cite_put <- function(orcid, pc, ...) {
+  orcid_prof_helper(orcid, file.path("work", pc), 
+    ctype = "application/vnd.citationstyles.csl+json", 
+    # ctype = "application/x-bibtex", 
+    parse = FALSE, ...)
 }
 
 has_doi <- function(x) {
@@ -219,18 +219,9 @@ do_all <- function(m, orcid, put_code, cr_format, cr_style, cr_locale, ...) {
   without_doi_citations <- lapply(without_doi, function(z) {
     zzz <- z$`external-ids.external-id`[[1]] %||% z$`work.external-ids.external-id`[[1]]
     pc <- z$`put-code` %||% z$`work.put-code`
-
-    ##try to extract BibTeX, if this fails use the conventional way
-    citation <- try(
-      extract_BibTeX(cite_put(orcid, pc, ctype = "application/vnd.orcid+json; qs=4")))
-
-    if(class(citation) == "try-error")
-      citation <- cite_put(orcid, pc)
-
-    list(put = pc, ids = zzz$`external-id-value`,
-         type = zzz$`external-id-type`, format = cr_format,
-         citation = citation)
-
+    list(put = pc, ids = zzz$`external-id-value`, 
+      type = zzz$`external-id-type`, format = cr_format,
+      citation = cite_put(orcid, pc))
   })
   as_dt(c(with_doi_citations, without_doi_citations))
 }

--- a/R/orcid_citations.R
+++ b/R/orcid_citations.R
@@ -232,5 +232,5 @@ do_all <- function(m, orcid, put_code, cr_format, cr_style, cr_locale, ...) {
          citation = citation)
 
   })
-  as_dt(c(with_doi_citations, without_doi_citations))
+  suppressWarnings(as_dt(c(with_doi_citations, without_doi_citations)))
 }

--- a/R/orcid_citations.R
+++ b/R/orcid_citations.R
@@ -1,72 +1,72 @@
 #' Get citations
 #'
 #' @export
-#' @param orcid (character) Orcid identifier(s) of the form 
+#' @param orcid (character) Orcid identifier(s) of the form
 #' XXXX-XXXX-XXXX-XXXX. required.
-#' @param put_code (character/integer) one or more put codes. up to 
+#' @param put_code (character/integer) one or more put codes. up to
 #' 50. optional
-#' @param cr_format Used in Crossref queries only. Name of the format. One of 
+#' @param cr_format Used in Crossref queries only. Name of the format. One of
 #' "rdf-xml", "turtle",
-#' "citeproc-json", "citeproc-json-ish", "text", "ris", "bibtex" (default), 
-#' "crossref-xml", "datacite-xml","bibentry", or "crossref-tdm". The format 
+#' "citeproc-json", "citeproc-json-ish", "text", "ris", "bibtex" (default),
+#' "crossref-xml", "datacite-xml","bibentry", or "crossref-tdm". The format
 #' "citeproc-json-ish" is a format that is not quite proper citeproc-json.
 #' passed to `rcrossref::cr_cn`. The special "citeproc2bibtex" value asks
-#' for citeproc-json from Crossref, then converts it into bibtex format 
+#' for citeproc-json from Crossref, then converts it into bibtex format
 #' using [handlr::HandlrClient]
-#' @param cr_style Used in Crossref queries only. A CSL style (for text 
-#' format only). See ‘get_styles()’ for options. Default: apa. 
+#' @param cr_style Used in Crossref queries only. A CSL style (for text
+#' format only). See ‘get_styles()’ for options. Default: apa.
 #' passed to `rcrossref::cr_cn`
-#' @param cr_locale Used in Crossref queries only. Language locale. 
+#' @param cr_locale Used in Crossref queries only. Language locale.
 #' See [Sys.getlocale], passed to `rcrossref::cr_cn`
 #' @param ... Curl options passed on to [crul::HttpClient]
 #' @template deets
 #' @details This function is focused on getting citations only.
 #' You can get all citations for an ORCID, or for certain works
 #' using a PUT code, or for many PUT codes.
-#' 
-#' We attempt to get citations via Crossref using \pkg{rcrossref} 
-#' whenever possible as they are the most flexible and don't have as 
-#' many mistakes in the text. If there is no DOI, we fetch the 
+#'
+#' We attempt to get citations via Crossref using \pkg{rcrossref}
+#' whenever possible as they are the most flexible and don't have as
+#' many mistakes in the text. If there is no DOI, we fetch the
 #' citation from ORCID.
-#' 
+#'
 #' Right now we get JSON citations back. We'd like to support bibtex
 #' format. DOI.org supports this but not ORCID.
 #'
 #' @return data.frame, with the columns:
-#' 
+#'
 #' - put: ORCID PUT code, identifying the work identifier in ORCID's records
 #' - id: the external identifier
 #' - id_type: the type of external identifier
 #' - format: the citation format retrieved
 #' - citation: the citation as JSON
-#' 
+#'
 #' @examples \dontrun{
 #' (res <- orcid_citations(orcid = "0000-0002-9341-7985"))
 #' (res2 <- orcid_citations(orcid = "0000-0002-1642-628X"))
 #' (res2 <- orcid_citations(orcid = c("0000-0002-9341-7985", "0000-0002-1642-628X")))
-#' 
+#'
 #' # get individual works
 #' ## a single put code
 #' (a <- orcid_citations(orcid = "0000-0002-9341-7985", put_code = 5011717))
 #' ## many put codes
-#' (b <- orcid_citations(orcid = "0000-0002-9341-7985", 
+#' (b <- orcid_citations(orcid = "0000-0002-9341-7985",
 #'    put_code = c(5011717, 15536016)))
-#' 
+#'
 #' # request other formats, Crossref only
 #' orcid_citations(orcid = "0000-0002-9341-7985", cr_format = "turtle")
-#' 
+#'
 #' # parse citation data if you wish
 #' # for parsing bibtex can use bibtex package or others
 #' (res <- orcid_citations(orcid = "0000-0002-9341-7985"))
 #' lapply(res[res$format == "csl-json", "citation"][[1]], jsonlite::fromJSON)
-#' 
+#'
 #' # lots of citations
 #' orcid_citations(orcid = "0000-0001-8642-6325")
-#' 
+#'
 #' # example with no external identifier, returns NA's
 #' orcid_citations(orcid = "0000-0001-8642-6325", 26222265)
 #' }
-orcid_citations <- function(orcid, put_code = NULL, cr_format = "bibtex", 
+orcid_citations <- function(orcid, put_code = NULL, cr_format = "bibtex",
   cr_style = "apa", cr_locale = "en-US", ...) {
 
   if (!is.null(put_code)) {
@@ -76,7 +76,7 @@ orcid_citations <- function(orcid, put_code = NULL, cr_format = "bibtex",
   }
 
   tmp <- orcid_works(orcid, put_code)
-  
+
   dat <- if (!is.null(put_code)) {
     if (NROW(tmp[[1]]$works) > 1) {
       list(split(tmp[[1]]$works, tmp[[1]]$works$`work.put-code`))
@@ -87,9 +87,10 @@ orcid_citations <- function(orcid, put_code = NULL, cr_format = "bibtex",
     lapply(tmp, function(w) split(w$works, w$works$`put-code`))
   }
 
+
   if (length(orcid) > 1) {
-    Map(function(a, b) each_orcid(a, b, put_code, cr_format, cr_style, cr_locale), 
-      dat, orcid, ...) 
+    Map(function(a, b) each_orcid(a, b, put_code, cr_format, cr_style, cr_locale),
+      dat, orcid, ...)
   } else {
     do_all(dat[[1]], orcid, put_code, cr_format, cr_style, cr_locale, ...)
   }
@@ -108,9 +109,9 @@ each_orcid <- function(m, orcid, put_code, cr_format, cr_style, cr_locale, ...) 
         process_cites(df, pc, orcid, cr_format, cr_style, cr_locale, ...)
       } else {
         df <- z$`external-ids`
-        Map(process_cites, df, pc, orcid = orcid, cr_format = cr_format, 
+        Map(process_cites, df, pc, orcid = orcid, cr_format = cr_format,
           cr_style = cr_style, cr_locale = cr_locale, ...)
-      } 
+      }
     } else {
       df <- z$`external-ids.external-id`[[1]]
       process_cites(df, pc, orcid, cr_format, cr_style, cr_locale, ...)
@@ -124,7 +125,7 @@ each_orcid <- function(m, orcid, put_code, cr_format, cr_style, cr_locale, ...) 
 
 process_cites <- function(df, pc, orcid, cr_format, cr_style, cr_locale, ...) {
   if (length(df) == 0) {
-    return(list(put = pc, id = NA_character_, id_type = NA_character_, 
+    return(list(put = pc, id = NA_character_, id_type = NA_character_,
       format = NA_character_, citation = ""))
   }
   if ("doi" %in% df$`external-id-type`) {
@@ -164,10 +165,10 @@ cite_doi <- function(x, cr_format = "bibtex", cr_style = "apa", cr_locale = "en-
   rcrossref::cr_cn(x, format = cr_format, style = cr_style, locale = cr_locale, raw = TRUE, ...)
 }
 
-cite_put <- function(orcid, pc, ...) {
-  orcid_prof_helper(orcid, file.path("work", pc), 
-    ctype = "application/vnd.citationstyles.csl+json", 
-    # ctype = "application/x-bibtex", 
+cite_put <- function(orcid, pc, ctype = "application/vnd.citationstyles.csl+json", ...) {
+  orcid_prof_helper(orcid, file.path("work", pc),
+    ctype = ctype,
+    #ctype = "application/x-bibtex",
     parse = FALSE, ...)
 }
 
@@ -219,9 +220,18 @@ do_all <- function(m, orcid, put_code, cr_format, cr_style, cr_locale, ...) {
   without_doi_citations <- lapply(without_doi, function(z) {
     zzz <- z$`external-ids.external-id`[[1]] %||% z$`work.external-ids.external-id`[[1]]
     pc <- z$`put-code` %||% z$`work.put-code`
-    list(put = pc, ids = zzz$`external-id-value`, 
+
+    ##try to extract BibTeX, if this fails use the conventional way
+    citation <- try(
+      extract_BibTeX(cite_put(orcid, pc, ctype = "application/vnd.orcid+json; qs=4")))
+
+    if(class(citation) == "try-error")
+      citation <- cite_put(orcid, pc)
+
+    list(put = pc, ids = zzz$`external-id-value`,
       type = zzz$`external-id-type`, format = cr_format,
-      citation = cite_put(orcid, pc))
+      citation = citation)
+
   })
   as_dt(c(with_doi_citations, without_doi_citations))
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -172,7 +172,7 @@ path_picker <- function(put_code, summary, pth_single) {
 #'was found or the BibTeX record is invalid, the input is passed
 #'through without modifying it
 #'
-#'@seealso [jsonlite::fromJSON], [cite_put]
+#'@seealso [jsonlite::fromJSON], `cite_put`
 #'
 #'@md
 #'@nord

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -18,7 +18,7 @@ orc_GET <- function(url, args = list(), ctype = ojson, ...) {
   )
   res <- cli$get(query = args)
   errs(res)
-  res$parse("UTF-8")
+  res$parse("UTF-8") 
 }
 
 check_key <- function() {
@@ -110,12 +110,12 @@ orcid_prof_helper <- function(x, path, ctype = ojson, parse = TRUE, ...) {
 switch_parser <- function(ctype, x) {
   switch(
     ctype,
-    `application/vnd.orcid+xml; qs=5` = px(x),
-    `application/orcid+xml; qs=3` = px(x),
-    `application/xml` = px(x),
-    `application/vnd.orcid+json; qs=4` = pj(x),
-    `application/orcid+json; qs=2` = pj(x),
-    `application/json` = pj(x),
+    `application/vnd.orcid+xml; qs=5` = px(x), 
+    `application/orcid+xml; qs=3` = px(x), 
+    `application/xml` = px(x), 
+    `application/vnd.orcid+json; qs=4` = pj(x), 
+    `application/orcid+json; qs=2` = pj(x), 
+    `application/json` = pj(x), 
     `application/vnd.citationstyles.csl+json` = pj(x),
     stop("no parser found for ", ctype)
   )
@@ -133,7 +133,7 @@ orcid_putcode_helper <- function(path, orcid, put_code, format, ...) {
   pth <- if (is.null(put_code)) path else file.path(path, put_code)
   if (length(pth) > 1) {
     stats::setNames(
-      Map(function(z) orcid_prof_helper(orcid, z, ctype = format), pth),
+      Map(function(z) orcid_prof_helper(orcid, z, ctype = format), pth), 
       put_code)
   } else {
     nmd <- if (!is.null(put_code)) put_code else orcid
@@ -159,84 +159,4 @@ path_picker <- function(put_code, summary, pth_single) {
     }
     file.path(pth_single, "summary")
   }
-}
-
-#'##extract BibTeX from ORCID string if available
-#'@param x the output of `cite_put()`
-#'
-#'@return Function returns a formated BibTeX record, if nothing
-#'was found or the BibTeX record is invalid, the input is passed
-#'through without modifying it
-#'@md
-#'@nord
-extract_BibTeX <- function(x) {
-  ##do we have a BibTeX entry? if not do nothing
-  if (grepl(pattern = "\"citation-type\" : \"bibtex\"",
-            x = x,
-            fixed = TRUE)) {
-
-
-    ##remove all line breaks, they cause too many problems
-    x <- gsub("\\n", replacement = "", x, fixed = TRUE, useBytes = TRUE)
-    x <- gsub("\n", replacement = "", x, fixed = TRUE, useBytes = TRUE)
-
-    ##this string extraction might be fragile ... on verra
-    bib <- substr(
-      x = x,
-      start = regexpr("@[a-z]+\\{", x, perl = TRUE, useBytes = FALSE),
-      stop =  regexpr(
-        "\\}[^a-z\\}]+\\}\\,[^a-z\\}]+(?=\\\"type\\\")",
-        x,
-        perl = TRUE,
-        useBytes = FALSE
-      )
-    )
-
-    ##make sure we do not break the function
-    ##and if we find no valid BibTeX entry we show where
-    if(bib == ""){
-      pc <- strsplit(
-        unlist(
-          regmatches(x, gregexpr("put-code\"\\s\\:\\s[0-9]+", x), invert = FALSE)),
-        " : ", fixed = TRUE)[[1]][2]
-      warning(paste0("BibTeX record not valid for record with put-code: ", pc), call. = FALSE)
-      return(x)
-    }
-
-    ##houskeeping to avoid BibTeX format problems
-    ##>> check for double backslash, there are probably wrong
-    bib <- gsub("\\\\", replacement = "\\", bib, fixed = TRUE)
-
-    ##>> extract BibTeX entries
-    bib_type <- regmatches(bib, regexpr("@[a-z]+", bib, perl = TRUE))
-    bib_keywords <- unlist(regmatches(bib, gregexpr("[a-z]+(?=\\s*?=)", bib, perl = TRUE)))
-    bib_entries <- trimws(unlist(strsplit(bib, split = "[a-z]+\\s*?="))[-1])
-    names(bib_entries) <- bib_keywords
-
-    #>> missing or wrong cite keys cause all kind of trouble, we reset them
-    if(any(c("author", "year") %in% bib_keywords)){
-      cite_key <- trimws(strsplit(bib_entries["author"], "and", fixed = TRUE)[[1]][1])
-      cite_key <- strsplit(cite_key, ",", fixed = TRUE)[[1]][1]
-      cite_key <- regmatches(cite_key, gregexpr("[[:alpha:]]+", cite_key))[[1]]
-      cite_key <- paste0(
-        cite_key, "_",
-        regmatches( bib_entries["year"], gregexpr("[[:digit:]]+", bib_entries["year"]))[[1]][1],
-        paste(sample(letters, 3, TRUE), collapse = ""))
-
-    }else{
-      cite_key <- paste(sample(letters, 12, replace = TRUE), collapse = "")
-
-    }
-
-    ##>> glue everything together and add line breaks and tabs
-    x <-  paste0(paste0(bib_type, "{", cite_key, ",\n"),
-                 paste(paste0("\t", bib_keywords, " = ", bib_entries),
-                       collapse = "\n"))
-
-    ##>> fix last bracket to have a nice record entry
-    x <- paste0(strtrim(x, nchar(x) - 1), "\n}")
-
-  }
-
-  return(x)
 }

--- a/tests/testthat/test-extract_bibtex.R
+++ b/tests/testthat/test-extract_bibtex.R
@@ -1,0 +1,50 @@
+test_that("extract_bibtex - basic functionality test", {
+  skip_on_cran()
+
+  vcr::use_cassette("extract_bibtex", {
+    aa <- cite_put(orcid = "0000-0002-0734-2199", pc = "40038622", ctype = "application/vnd.orcid+json; qs=4")
+
+  })
+
+  ## in order to test everything, we have to modify the string a little bit
+  ## (1) - the record is no BibTeX record
+  aa_noBibTeX <- jsonlite::fromJSON(aa)
+  aa_noBibTeX$citation$`citation-type` <- "unknown"
+  aa_noBibTeX <- jsonlite::toJSON(aa_noBibTeX)
+
+  ## (2) - the citekey is not ok
+  aa_wrong_citekey <- jsonlite::fromJSON(aa)
+  aa_wrong_citekey$citation$`citation-value` <-
+    sub(
+      pattern = "@article{Kreutzer:2012ty",
+      replacement = "@article{Kreutzer,2012ty",
+      x = aa_wrong_citekey$citation$`citation-value`,
+      fixed = TRUE
+    )
+  aa_wrong_citekey <- jsonlite::toJSON(aa_wrong_citekey)
+
+  ## (3) - the citekey does not exist
+  aa_missing_citekey <- jsonlite::fromJSON(aa)
+  aa_missin_citekey$citation$`citation-value` <-
+    sub(
+      pattern = "@article{Kreutzer:2012ty",
+      replacement = "@article{",
+      x = aa_missin_citekey$citation$`citation-value`,
+      fixed = TRUE
+    )
+  aa_missing_citekey <- jsonlite::toJSON(aa_missing_citekey)
+
+  ## test all cases
+  ## (0) - standard (nothing should go wrong)
+  expect_is(extract_bibtex(aa), "character")
+
+  ## (1) - no BibTeX record
+  expect_warning(extract_bibtex(aa_noBibTeX), regexp = "No BibTeX record found for record with put-code")
+
+  ## (2) - odd citekey (currently it just corrects, so smooth passage)
+  expect_is(extract_bibtex(aa_wrong_citekey), "character")
+
+  ## (3) - missing citekey, if it works it passes
+  expect_is(extract_bibtex(aa_missing_citekey), "character")
+
+})

--- a/tests/testthat/test-extract_bibtex.R
+++ b/tests/testthat/test-extract_bibtex.R
@@ -25,11 +25,11 @@ test_that("extract_bibtex - basic functionality test", {
 
   ## (3) - the citekey does not exist
   aa_missing_citekey <- jsonlite::fromJSON(aa)
-  aa_missin_citekey$citation$`citation-value` <-
+  aa_missing_citekey$citation$`citation-value` <-
     sub(
       pattern = "@article{Kreutzer:2012ty",
       replacement = "@article{",
-      x = aa_missin_citekey$citation$`citation-value`,
+      x = aa_missing_citekey$citation$`citation-value`,
       fixed = TRUE
     )
   aa_missing_citekey <- jsonlite::toJSON(aa_missing_citekey)

--- a/tests/testthat/test-extract_bibtex.R
+++ b/tests/testthat/test-extract_bibtex.R
@@ -1,9 +1,8 @@
-test_that("extract_bibtex - basic functionality test", {
+test_that("extract_bibtex_basic_test", {
   skip_on_cran()
 
   vcr::use_cassette("extract_bibtex", {
     aa <- cite_put(orcid = "0000-0002-0734-2199", pc = "40038622", ctype = "application/vnd.orcid+json; qs=4")
-
   })
 
   ## in order to test everything, we have to modify the string a little bit
@@ -46,5 +45,4 @@ test_that("extract_bibtex - basic functionality test", {
 
   ## (3) - missing citekey, if it works it passes
   expect_is(extract_bibtex(aa_missing_citekey), "character")
-
 })

--- a/tests/testthat/test-orcid_citations.R
+++ b/tests/testthat/test-orcid_citations.R
@@ -1,12 +1,10 @@
-test_that("orcid_citations basic test", {
+test_that("orcid_citations_basic_test", {
   skip_on_cran()
 
   ##this tests a specific ORCID record with a bibtex record to extract
-  vcr::use_cassette("orcid_citations with bibtex", {
+  vcr::use_cassette("orcid_citations_with_bibtex", {
     aa <- orcid_citations(orcid = "0000-0002-0734-2199", put_code = "40038622")
-
   })
 
   expect_is(aa, "data.frame")
-
 })

--- a/tests/testthat/test-orcid_citations.R
+++ b/tests/testthat/test-orcid_citations.R
@@ -1,0 +1,12 @@
+test_that("orcid_citations basic test", {
+  skip_on_cran()
+
+  ##this tests a specific ORCID record with a bibtex record to extract
+  vcr::use_cassette("orcid_citations with bibtex", {
+    aa <- orcid_citations(orcid = "0000-0002-0734-2199", put_code = "40038622")
+
+  })
+
+  expect_is(aa, "data.frame")
+
+})


### PR DESCRIPTION
## Summary

The function `rorcid::orcid_citations()`attempts to get BibTeX records from Crossref. However, if this fails (usually for entries without DOI), only the record from ORCID is returned. However, this record may have already a BibTeX entry. It just needs to get extracted. My commit attempts to implement support to extract those records until the ORCID API provides such functionality. 

## Description

* zzz.R: New helper function called `extract_BibTeX()` added. This function parses the string returned from ORCID and tries to extract the BibTeX entry. The function works with the input from `cite_put()`.  If nothing is available or the string is invalid, or the parsing fails, the input is passed through. 
I added comments in the code along with a rough roxygen documentation (no Rd). 

* orcid_citations.R 
  * The function `cite_put()` gained a new argument `ctype` to pass the relevant parser information
  * Below `without_doi_citations` I added a few lines to pass the output of `cite_put()` to the function `extract_BibTeX()` (wrapper). I tested the function, however, to avoid that I break something, the call is wrapped in a `try()`. If it fails, the user gets the standard output. 

The approach may appear a little bit heavy, but I tested nearly 100 different records and the way finally chosen, reflects and addresses various difficulties I encountered. 

## Related Issue

I am not aware of related issues, I do hope I did not overlook something. The only comment I did find was in the manual itself, where it is written: 

> Right now we get JSON citations back. We'd like to support bibtex format. DOI.org supports this but not ORCID.

## Example

The following call will extract all publications from my ORCID profile, which include publications without DOI. In the 'old' version 'only' the standard ORCID record was returned. 

```r
pubs <- rorcid::orcid_citations("0000-0002-0734-2199")
```

## Tests

The file 'orcid_citations.R' is not yet covered by tests, so I did not add a test, but of course I can support writting a proper test for the function.