### PR TITLE
require token env var to run tests, and ignore if on CRAN

### DIFF
--- a/tests/testthat/helper-rorcid.R
+++ b/tests/testthat/helper-rorcid.R
@@ -1,6 +1,16 @@
+# don't run tests is token not set
+if ( 
+  identical(Sys.getenv("NOT_CRAN"), "true") &&
+  Sys.getenv("ORCID_TOKEN", "") == ""
+) {
+  stop("set an ORCID_TOKEN env var before running tests", 
+    call. = FALSE)
+}
+
 # set up vcr
 library("vcr")
 invisible(vcr::vcr_configure(
-    dir = "../fixtures",
-    filter_sensitive_data = list("<<rorcid_bearer_token>>" = Sys.getenv('ORCID_TOKEN'))
+  dir = "../fixtures",
+  filter_sensitive_data =
+    list("<<rorcid_bearer_token>>" = Sys.getenv('ORCID_TOKEN'))
 ))


### PR DESCRIPTION
from #78